### PR TITLE
Add build support for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,23 @@ else()
 endif()
 
 find_package(FLEX REQUIRED)
+
+if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+  execute_process(
+        COMMAND brew --prefix flex 
+        RESULT_VARIABLE BREW_FLEX
+        OUTPUT_VARIABLE BREW_FLEX_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if (BREW_FLEX EQUAL 0 AND EXISTS "${BREW_FLEX_PREFIX}")
+    set(FLEX_EXECUTABLE "${BREW_FLEX_PREFIX}/bin/flex")
+    set(FLEX_INCLUDE_DIRS "${BREW_FLEX_PREFIX}/include")
+  else()
+    message(FATAL_ERROR "Could not find flex for macOS!")
+    exit()
+  endif()
+endif()
+
 if (FLEX_FOUND AND NOT ${FLEX_INCLUDE_DIRS} STREQUAL "FLEX_INCLUDE_DIR-NOTFOUND")
     message(STATUS "Flex include directories: ${FLEX_INCLUDE_DIRS}")
     message(STATUS "Flex executable: ${FLEX_EXECUTABLE}")


### PR DESCRIPTION
The macOS has a built-in version of flex which is outdated. 
However, certain parts of the macOS system relies on that specific flex. Thus package manager (like `brew`) could only install flex in other path (instead of `/usr/bin`).

The original `CMakeLists.txt` would find the outdated flex in `/usr/bin` and could not find the related include path.
In this pull request,  I add a check in the `CMakeLists.txt` setting flex-related variable to the correct location installed by `brew`.

